### PR TITLE
Fix TypeError when a JSON file can not be read

### DIFF
--- a/phpstan/baseline.neon
+++ b/phpstan/baseline.neon
@@ -2971,11 +2971,6 @@ parameters:
 			path: ../src/Composer/Json/JsonFile.php
 
 		-
-			message: "#^Parameter \\#1 \\$json of static method Composer\\\\Json\\\\JsonFile\\:\\:parseJson\\(\\) expects string\\|null, string\\|false\\|null given\\.$#"
-			count: 1
-			path: ../src/Composer/Json/JsonFile.php
-
-		-
 			message: "#^Parameter \\#1 \\$json of static method Composer\\\\Json\\\\JsonFile\\:\\:validateSyntax\\(\\) expects string, string\\|false given\\.$#"
 			count: 1
 			path: ../src/Composer/Json/JsonFile.php

--- a/src/Composer/Json/JsonFile.php
+++ b/src/Composer/Json/JsonFile.php
@@ -114,6 +114,10 @@ class JsonFile
             throw new \RuntimeException('Could not read '.$this->path."\n\n".$e->getMessage());
         }
 
+        if ($json === false) {
+            throw new \RuntimeException('Could not read '.$this->path);
+        }
+
         return static::parseJson($json, $this->path);
     }
 


### PR DESCRIPTION
<!-- Please remember to select the appropriate branch:

For bug or doc fixes pick the oldest branch where the fix applies (e.g. `2.2` if the 2.2 LTS is affected, `1.10` if it is a critical fix that should be fixed in Composer 1, otherwise `main`)

For new features and everything else, use the main branch. -->
